### PR TITLE
PopupMenu divider

### DIFF
--- a/src/lib/components/MultiSelect.svelte
+++ b/src/lib/components/MultiSelect.svelte
@@ -22,6 +22,12 @@
   export let getOptions: (search: string) => Promise<PopupMenuTypes[]>|PopupMenuTypes[]
   export let id = randomid()
   export let disabled = false
+  export let menuContainerClass = ''
+  export let menuClass = ''
+  export let menuItemClass = ''
+  export let menuItemHilitedClass = ''
+  export let inputClass = ''
+  export let menuDividerClass = ''
   /** The maximum number of selections allowed before making new selections is disabled. Default of 0 is unlimited. */
   export let maxSelections = 0
   /** Consuming components may need to make decisions about what to display or return as options in the popup based
@@ -37,13 +43,6 @@
   export let descid: string | undefined = undefined
   /** You can define your own PopupMenu and pass for that to be used or accept DefaultPopupMenu. */
   export let PopupMenu = DefaultPopupMenu
-  export let menuContainerClass: string|undefined = undefined
-  export let menuClass: string|undefined = undefined
-  export let menuItemClass: string|undefined = undefined
-  export let menuItemHilitedClass: string|undefined = undefined
-  export let inputClass: string|undefined = undefined
-  export let menuDividerClass: string|undefined = undefined
-  $: _inputClass = inputClass ?? ''
 
   let menushown: boolean
   let loading = false
@@ -140,10 +139,11 @@
         on:click|preventDefault|stopPropagation={() => !disabled && removeSelection(option, i, 1)} on:mousedown={e => disabled && e.preventDefault()}
         aria-selected="true">
         {option.label || option.value}
+        <i aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256"><path fill="currentColor" d="M205.66 194.34a8 8 0 0 1-11.32 11.32L128 139.31l-66.34 66.35a8 8 0 0 1-11.32-11.32L116.69 128L50.34 61.66a8 8 0 0 1 11.32-11.32L128 116.69l66.34-66.35a8 8 0 0 1 11.32 11.32L139.31 128Z"/></svg></i>
         <ScreenReaderOnly>, click to deselect</ScreenReaderOnly>
       </li>
     {/each}
-    <li class={`input ${_inputClass ?? ''}`}>
+    <li class={`input ${inputClass}`}>
       <input type="text" {id} {name} {disabled} {placeholder}
         bind:this={inputelement} bind:value={inputvalue} on:blur
         on:focus={inputfocus} on:keydown={inputkeydown}
@@ -199,6 +199,7 @@
     height: 100%;
   }
   .multiselect-pill {
+    position: relative;
     cursor: pointer;
     flex-grow: 0;
     margin-right: 0.3em;
@@ -207,7 +208,21 @@
     border: var(--multiselect-pill-border, 1px solid gray);
     background-color: var(--multiselect-pill-bg, transparent);
     color: var(--multiselect-pill-text, black);
-    padding: var(--multiselect-pill-padding, 0.3em 0.5em);
+    padding: var(--multiselect-pill-padding-top, 0.3em) var(--multiselect-pill-padding-left, 0.5em);
+    padding-right: calc(var(--multiselect-pill-padding-left, 0.5em) + 1.1em);
+  }
+  .multiselect-pill i {
+    display: block;
+    position: absolute;
+    top: 50%;
+    right: calc(var(--multiselect-pill-padding-left, 0.5em) - 0.1em);
+    transform: translateY(-50%);
+    width: 1em;
+    height: 1em;
+  }
+  .multiselect-pill svg {
+    width: 100%;
+    height: 100%;
   }
   .multiselect-selected.disabled {
     opacity: 0.5;

--- a/src/lib/components/PopupMenu.svelte
+++ b/src/lib/components/PopupMenu.svelte
@@ -57,19 +57,12 @@
   /** When there are no items (e.g. it's a filtered search and there were no results), we still display one
   disabled item in the menu to let the user know what is going on. Use this prop to specify the message. */
   export let emptyText: string|undefined = undefined
-  export let menuContainerClass = undefined
-  export let menuClass = undefined
-  export let menuItemClass = undefined
-  export let menuItemHilitedClass = undefined
-  export let menuItemSelectedClass = undefined
-  export let menuDividerClass = undefined
-
-  $: _menuContainerClass = menuContainerClass ?? ''
-  $: _menuClass = menuClass ?? ''
-  $: _menuItemClass = menuItemClass ?? ''
-  $: _menuItemHilitedClass = menuItemHilitedClass ?? ''
-  $: _menuItemSelectedClass = menuItemSelectedClass ?? ''
-  $: _menuDividerClass = menuDividerClass ?? ''
+  export let menuContainerClass = ''
+  export let menuClass = ''
+  export let menuItemClass = ''
+  export let menuItemHilitedClass = ''
+  export let menuItemSelectedClass = ''
+  export let menuDividerClass = ''
 
   let menuelement: HTMLElement|undefined
   const itemelements: HTMLElement[] = []
@@ -242,9 +235,9 @@
 {#if menushown}
   <div use:portal={usePortal === true ? undefined : (usePortal || null)}
        use:glue={{ target: buttonelement, align, cover, adjustparentheight, store: computedalign }}
-       class={_menuContainerClass}>
+       class={menuContainerClass}>
     <ul bind:this={menuelement} id={menuid} role='listbox' style={width ? `width: ${width}` : ''}
-        class={_menuClass} class:hasSelected class:defaultmenu={!menuClass && !menuContainerClass}
+        class={menuClass} class:hasSelected class:defaultmenu={!menuClass && !menuContainerClass}
         on:keydown={onkeydown}>
       {#each items as item, i ('value' in item ? item.value : `popupmenu_divider_${i}`)}
         {#if 'value' in item && (showSelected || item.value !== value)}
@@ -252,7 +245,7 @@
           <li
             id={`${menuid}-${i}`}
             bind:this={itemelements[i]}
-            class={`${_menuItemClass} ${i === hilited ? _menuItemHilitedClass : ''} ${value === item.value ? _menuItemSelectedClass : ''}`}
+            class={`${menuItemClass} ${i === hilited ? menuItemHilitedClass : ''} ${value === item.value ? menuItemSelectedClass : ''}`}
             class:disabled={!!item.disabled}
             class:hilited={!menuItemHilitedClass && i === hilited}
             class:selected={showSelected && !menuItemSelectedClass && value === item.value}
@@ -263,11 +256,11 @@
             aria-disabled={item.disabled}
           ><slot {item} label={item.label || item.value} hilited={i === hilited} selected={value === item.value}>{item.label || item.value}</slot></li>
         {:else if 'divider' in item && item.divider}
-          <li class={`divider ${_menuDividerClass}`} class:group={isNotBlank(item.label)} aria-disabled={true}>{item.label}</li>
+          <li class={`divider ${menuDividerClass}`} on:mousedown|stopPropagation|preventDefault class:group={isNotBlank(item.label)}>{item.label}</li>
         {/if}
       {/each}
       {#if items.length === 0}
-        <li role="option" class={`${_menuItemClass} disabled`} aria-live="assertive" aria-selected={false}>
+        <li role="option" class={`${menuItemClass} disabled`} aria-live="assertive" aria-selected={false}>
           <slot name="noresults">
             {#if !emptyText}
               <span aria-hidden="true">{'¯\\_(ツ)_/¯'}</span><ScreenReaderOnly>{emptyText || 'no results found'}</ScreenReaderOnly>
@@ -328,6 +321,7 @@
   li.divider {
     height: 0px;
     border-top: 2px solid slategray;
+    cursor: default;
   }
   li.divider.group {
     height: auto;

--- a/src/lib/types/PopupMenu.ts
+++ b/src/lib/types/PopupMenu.ts
@@ -1,8 +1,33 @@
-/** ```ts
-{ value: string, lable? string, disabled?: boolean }
-``` */
+/**  The basic information assocaited with individual choices that are presented in a PopupMenu. */
 export interface PopupMenuItem {
+  /** The value returned by the PopupMenu when the associated item is selected. */
   value: string
+  /** An optional display string to show in the menu for the associated `value`. */
   label?: string
+  /** Toggles the choice as one that's visible but is disabled and unclickable until conditions
+   * are met that would cause it to become enabled. */
   disabled?: boolean
 }
+
+/** A PopupMenu list native type for displaying */
+export interface PopupMenuDivider {
+  /** Toggle for whether this instance of this type is shown. */
+  divider: boolean
+  /** Optional labeling to display. Useful for dividers used as group headers.
+   * We may want to update PopupMenu to use <optgroup lable=
+   */
+  label?: string
+}
+
+/** To support ARIA best practices for groups within listboxes as popup menus
+ * we'll need to group options under sub-lists. This interface provides a means
+ * for passing such to PopupMenu.
+ * @note Not currently in use. */
+export interface PopupMenuGroup {
+  /** The label for the group. */
+  lable: string
+  /** The listing of options that would be listed under the parent `<ul>`. */
+  options: PopupMenuTypes[]
+}
+
+export type PopupMenuTypes = (PopupMenuDivider | PopupMenuItem)

--- a/src/test/MultiSelectTest.svelte
+++ b/src/test/MultiSelectTest.svelte
@@ -47,7 +47,7 @@
     { value: 'other', label: 'Other Transportation' }
   ]
   const carItems = [carsHeader, ...thirdItems]
-  let selectedHybrid = []
+  let selectedHybrid: PopupMenuItem[] = []
   $: selectedHybridSet = new Set(selectedHybrid.map(s => s.value))
   $: carOptionsAvailable = carItems.filter(o => 'value' in o && !selectedHybridSet.has(o.value)).length > 1
   $: commonOptionsAvailable = commonItems.filter(o => 'value' in o && !selectedHybridSet.has(o.value)).length > 1
@@ -129,6 +129,6 @@
     width: 100%
   }
   :global(.multiselect-dividers) {
-    background-color: darkslategrey;
+    background-color: #EEEEEE;
   }
 </style>


### PR DESCRIPTION
After reviewing ARIA 1.2 specifications I decided the customCSS approach is not the way we want to go as it encourages practices in the wrong direction for communicating the cues provided by CSS to aria states and roles. Switched to a different branch that forgoes the individual list item css passing.

Went with Nick's commit to update for the native divider element that can be presented in PopupMenu. I kept the label on that divider for now though I now think we should make plans in the future to get rid of it and make use of the PopupMenuGroup interface when we have time, in the future, to implement that which I very much want to do. That would follow the best practices of nesting lists within the parent list and giving those an aria-role of "group" to more natively support ARIA interactions within our custom selection interface.